### PR TITLE
fix(perfiles): profile picture and rol for the meta head tags

### DIFF
--- a/src/components/FecHead/index.tsx
+++ b/src/components/FecHead/index.tsx
@@ -3,12 +3,14 @@ import Head from 'next/head';
 interface FecHeadProps {
   title: string;
   description?: string;
+  ogImage?: string;
 }
 
 const FecHead: React.FC<FecHeadProps> = ({
   title = 'FrontendCafé ',
   description = 'Somos una comunidad de personas interesadas en tecnología y ciencias informáticas en donde charlamos sobre lenguajes de programación, diseño web, infraestructura, compartimos dudas, preguntamos y respondemos.',
   children,
+  ogImage = 'https://frontend.cafe/logo-square.png',
 }) => {
   return (
     <Head>
@@ -20,17 +22,11 @@ const FecHead: React.FC<FecHeadProps> = ({
       <meta name="twitter:title" content={`${title} - FrontendCafé `} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:site" content="@frontendcafe" />
-      <meta
-        name="twitter:image"
-        content="https://frontend.cafe/logo-square.png"
-      />
+      <meta name="twitter:image" content={ogImage} />
       {/* Open Graph */}
       <meta property="og:title" content={`${title} - FrontendCafé `} />
       <meta property="og:description" content={description} />
-      <meta
-        property="og:image"
-        content="https://frontend.cafe/logo-square.png"
-      />
+      <meta property="og:image" content={ogImage} />
       {/* Imports */}
       <link
         href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -8,6 +8,7 @@ type LayoutProps = {
   mode?: 'main' | 'simple';
   title?: string;
   description?: string;
+  ogImage?: string;
   preview?: boolean;
   settings?: Settings;
 };
@@ -41,13 +42,14 @@ const Layout: React.FC<LayoutProps> = ({
   mode = 'main',
   title,
   description,
+  ogImage,
   preview = false,
   children,
   settings,
 }) => {
   return (
     <>
-      <FecHead title={title} description={description} />
+      <FecHead title={title} description={description} ogImage={ogImage} />
       {
         {
           main: (

--- a/src/pages/perfiles/[slug].tsx
+++ b/src/pages/perfiles/[slug].tsx
@@ -23,6 +23,8 @@ const ProfilePage = ({ profile, preview }: Props) => {
   return (
     <Layout
       title={`Perfiles en FrontendCafé  | ${profile?.name}`}
+      description={profile?.role}
+      ogImage={profile?.ogImage.url}
       preview={preview}
     >
       <Head>


### PR DESCRIPTION
Add profiles image and role into the preview card for social media and when the link of the profile it is shared.