### PR TITLE
Added a default and minimum staffcard avatar size

### DIFF
--- a/src/components/StaffCard/index.tsx
+++ b/src/components/StaffCard/index.tsx
@@ -10,7 +10,7 @@ const StaffCard = ({ profile }: Props) => {
       <a href={profile.linkedin} target="_blank" rel="noreferrer">
         {profile.photo.src && (
           <img
-            className="rounded-full mx-auto sm:h-36 sm:w-36 md:h-32 md:w-32 object-cover"
+            className="rounded-full mx-auto h-36 w-36 md:h-32 md:w-32 object-cover"
             src={profile.photo.src}
             alt={profile.firstName}
           />


### PR DESCRIPTION
The width and the height were set starting from minimum screen sizes `sm:` from Tailwind. 
Now, the same sizes apply to smaller screens as well. 