### PR TITLE
fix(tweets): tweets fail to load when one of the tweets contains a poll

### DIFF
--- a/src/lib/twitter.ts
+++ b/src/lib/twitter.ts
@@ -108,7 +108,7 @@ export const getEmbeddedTweets = async (): Promise<EmbeddedTweet[]> => {
     return {
       ...tweet,
       media:
-        tweet?.attachments?.media_keys.map((key) =>
+        tweet?.attachments?.media_keys?.map((key) =>
           tweets.includes.media.find((media) => media.media_key === key),
         ) || [],
       referenced_tweets: getReferencedTweets(tweet, tweets),


### PR DESCRIPTION
Una encuesta es un tipo de `attachment`.

Pero a diferencia de otros attachments no tienen la prop `media_keys` sino que tienen la prop `poll_ids`.

Lo que hace este PR es evitar renderizar este tipo de attachments, en el futuro se podría handlear este caso para renderizar las encuestas.