### PR TITLE
feat(mentorias): use search params as search state

### DIFF
--- a/src/components/MentorList/index.tsx
+++ b/src/components/MentorList/index.tsx
@@ -76,7 +76,11 @@ const MentorList: React.FC<MentorListProps> = ({ mentors, topics }) => {
         >
           <option value="">Buscar</option>
           {sortedTopics?.map((topic, index) => (
-            <option value={topic._id} key={index}>
+            <option
+              value={topic._id}
+              key={index}
+              selected={topic._id === query.especialidad}
+            >
               {topic.title}
             </option>
           ))}


### PR DESCRIPTION
Guarda el estado del selector de mentorías en los query params de la URL, de esta forma se pueden compartir las búsquedas y referir a un conjunto de mentores de una determinada especialidad