### PR TITLE
[Profiles] Limit bio input to 500 chars

### DIFF
--- a/src/pages/talentos/nuevo.tsx
+++ b/src/pages/talentos/nuevo.tsx
@@ -436,6 +436,7 @@ const NewProfilePage: React.FC<NewProfileProps> = ({
                     }`}
                     {...register('description', { required: true })}
                     placeholder="Cuentanos un poco de tí"
+                    maxLength={500}
                   ></textarea>
                 </div>
                 <div className="flex items-center mb-4">


### PR DESCRIPTION
Add `maxLength` attr to "bio" input to limit its chars to 500

[Task](https://app.clickup.com/t/1p6rd4p)