### PR TITLE
fix: mentores sin temas

### DIFF
--- a/src/components/MentorList/index.tsx
+++ b/src/components/MentorList/index.tsx
@@ -49,9 +49,9 @@ const MentorList: React.FC<MentorListProps> = ({ mentors, topics }) => {
     const filterTopics = () => {
       const filtered = [];
       sortedMentors.forEach((mentor) => {
-        const find = mentor.topics.filter(
-          (topic) => topic._ref == query.especialidad,
-        );
+        const find =
+          mentor.topics?.filter((topic) => topic._ref == query.especialidad) ??
+          [];
         if (find.length > 0) filtered.push(mentor);
       });
       setFilteredMentors(filtered);


### PR DESCRIPTION
Al añadir a un mentor sin temas en sanity, el sitio de mentorías se rompe debido a que `mentor.topics` es `undefined` (honestamente pensaba que iba a ser `[]`).

Creo que desde sanity se puede añadir un default value pero de todas formas hice un fix para hacer al código del website más resiliente.