### PR TITLE
styles: renamed colors to match Tailwind CSS 3.0.0

### DIFF
--- a/src/components/EventPreview/index.tsx
+++ b/src/components/EventPreview/index.tsx
@@ -96,7 +96,7 @@ const EventPreview: React.FC<EventPreviewProps> = ({ event, past = false }) => {
             </span>
           </Card.Paragraph>
         )}
-        <div className="text-primary">
+        <div className="text-secondary">
           <BlockContent blocks={event.description} />
         </div>
       </Card.Body>

--- a/src/components/EventPreview/index.tsx
+++ b/src/components/EventPreview/index.tsx
@@ -91,12 +91,12 @@ const EventPreview: React.FC<EventPreviewProps> = ({ event, past = false }) => {
               locale: es,
             })}
             hrs
-            <span className="inline-block text-xs font-light text-gray-400">
+            <span className="inline-block text-xs font-light text-quaternary">
               Horario en tu ubicación actual
             </span>
           </Card.Paragraph>
         )}
-        <div className="text-gray-300">
+        <div className="text-primary">
           <BlockContent blocks={event.description} />
         </div>
       </Card.Body>

--- a/src/components/EventPreview/index.tsx
+++ b/src/components/EventPreview/index.tsx
@@ -91,12 +91,12 @@ const EventPreview: React.FC<EventPreviewProps> = ({ event, past = false }) => {
               locale: es,
             })}
             hrs
-            <span className="inline-block text-xs font-light text-coolGray-400">
+            <span className="inline-block text-xs font-light text-gray-400">
               Horario en tu ubicación actual
             </span>
           </Card.Paragraph>
         )}
-        <div className="text-coolGray-300">
+        <div className="text-gray-300">
           <BlockContent blocks={event.description} />
         </div>
       </Card.Body>

--- a/src/components/PreviewBanner/index.tsx
+++ b/src/components/PreviewBanner/index.tsx
@@ -2,7 +2,7 @@ const PreviewBanner: React.FC = () => {
   return (
     <div
       style={{ zIndex: 51 }}
-      className="bg-green-400 fixed font-semibold w-full text-center text-coolGray-50 py-2 uppercase"
+      className="bg-green-400 fixed font-semibold w-full text-center text-gray-50 py-2 uppercase"
     >
       Preview mode{' '}
       <a

--- a/src/components/PreviewBanner/index.tsx
+++ b/src/components/PreviewBanner/index.tsx
@@ -2,7 +2,7 @@ const PreviewBanner: React.FC = () => {
   return (
     <div
       style={{ zIndex: 51 }}
-      className="bg-green-400 fixed font-semibold w-full text-center text-gray-50 py-2 uppercase"
+      className="bg-green-400 fixed font-semibold w-full text-center text-primary py-2 uppercase"
     >
       Preview mode{' '}
       <a

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -63,7 +63,7 @@ const ToastNotification: React.FC<ToastNotificationProps> = ({
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           className={`fixed top-12 max-w-md w-11/12 rounded-lg overflow-hidden mx-auto inset-x-0 flex justify-center items-center 
-                     ${backgroundColorClass} text-gray-50 text-sm font-bold px-4 py-3 mt-2`}
+                     ${backgroundColorClass} text-primary text-sm font-bold px-4 py-3 mt-2`}
           role="alert"
           onClick={() => setShow(false)}
         >

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -63,7 +63,7 @@ const ToastNotification: React.FC<ToastNotificationProps> = ({
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           className={`fixed top-12 max-w-md w-11/12 rounded-lg overflow-hidden mx-auto inset-x-0 flex justify-center items-center 
-                     ${backgroundColorClass} text-coolGray-50 text-sm font-bold px-4 py-3 mt-2`}
+                     ${backgroundColorClass} text-gray-50 text-sm font-bold px-4 py-3 mt-2`}
           role="alert"
           onClick={() => setShow(false)}
         >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -82,8 +82,9 @@ module.exports = {
       },
       textColor: {
         primary: tailwindColors.gray[50],
-        secondary: tailwindColors.gray[300],
         tertiary: tailwindColors.gray[200],
+        secondary: tailwindColors.gray[300],
+        quaternary: tailwindColors.gray[400],
         accent: '#6366F1',
         informational: '#4991DA',
         lightBlue: '#00CCFF',


### PR DESCRIPTION
This commit uses the colors in our **tailwind.config.js** to match our design in Figma and adds a new custom property.

- **Use text-quaternary instead of text-coolGray-400.**
- **Use text-secondary instead of text-coolGray-300.**
- **Use text-primary instead of text-coolGray-50.**

Before:

![image](https://user-images.githubusercontent.com/6179522/152707186-d762d3f2-1d11-429d-be97-f211f97dc2e4.png)

After:

![image](https://user-images.githubusercontent.com/6179522/152707380-ce6e9852-923e-4431-b803-835a8e9c43ff.png)
