### PR TITLE
[Website] Arreglar espaciado en eventos, y errores de ortografía en faqs

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -4,13 +4,14 @@ import Link from 'next/link';
 import React from 'react';
 
 type CardActionProps = { href: string; className?: string };
+type ParagraphProps = { className?: string };
 
 type CardSubcomponents = {
   Header: React.FC;
   Image: React.FC<ImageProps>;
   Headline: React.FC;
   Title: React.FC;
-  Paragraph: React.FC;
+  Paragraph: React.FC<ParagraphProps>;
   Body: React.FC;
   Actions: React.FC;
   PrimaryAction: React.FC<CardActionProps>;
@@ -18,7 +19,7 @@ type CardSubcomponents = {
 };
 
 const Card: React.FC & CardSubcomponents = ({ children }) => (
-  <div className="flex flex-col justify-between h-full p-4 bg-zinc-800 rounded-md shadow-lg ">
+  <div className="flex flex-col justify-between h-full p-4 bg-zinc-800 rounded-md shadow-lg">
     {children}
   </div>
 );
@@ -55,9 +56,10 @@ const CardTitle: React.FC = ({ children }) => (
 
 const CardBody: React.FC = ({ children }) => <div>{children}</div>;
 
-const CardParagraph: React.FC = ({ children }) => (
-  <p className="cards-paragraph">{children}</p>
-);
+const CardParagraph: React.FC<ParagraphProps> = ({
+  children,
+  className = '',
+}) => <p className={`cards-paragraph ${className}`}>{children}</p>;
 
 const CardActions: React.FC = ({ children }) => (
   <div className="flex items-end flex-grow w-full mt-5">

--- a/src/components/EventPreview/index.tsx
+++ b/src/components/EventPreview/index.tsx
@@ -108,17 +108,19 @@ const EventPreview: React.FC<EventPreviewProps> = ({ event, past = false }) => {
 
       <Card.Body>
         {!past && (
-          <Card.Paragraph>
-            {format(new Date(event.date), 'd  MMMM - HH:mm ', {
-              locale: es,
-            })}
-            hrs <br />
-            <span className="inline-block text-xs font-light text-quaternary">
+          <div className="flex flex-col">
+            <Card.Paragraph>
+              {format(new Date(event.date), 'd  MMMM - HH:mm ', {
+                locale: es,
+              })}
+              hrs
+            </Card.Paragraph>
+            <Card.Paragraph className="p-0 text-xs font-light text-quaternary">
               Horario en tu ubicación actual
-            </span>
-          </Card.Paragraph>
+            </Card.Paragraph>
+          </div>
         )}
-        <div className="text-secondary">
+        <div className="text-secondary py-2">
           <PortableText blocks={event.description} serializers={serializers} />
         </div>
       </Card.Body>

--- a/src/pages/faqs.tsx
+++ b/src/pages/faqs.tsx
@@ -60,7 +60,13 @@ const Faqs: React.FC<FAQSProps> = ({ preview = false }) => {
                   hablar en inglés en público, mejorar la comunicación en inglés
                   partiendo desde el propio nivel, divertirnos, y conectarnos.
                   Puedes mirar cuando serán los próximos eventos en nuestra{' '}
-                  <a href="https://frontend.cafe/eventos"> agenda</a>
+                  <a
+                    href="https://frontend.cafe/eventos"
+                    className="text-informational"
+                  >
+                    agenda
+                  </a>
+                  .
                 </p>
               </details>
             </div>
@@ -70,8 +76,8 @@ const Faqs: React.FC<FAQSProps> = ({ preview = false }) => {
                   ¿Cuándo son los eventos de inglés?
                 </summary>
                 <p className="p-4">
-                  Los eventos de inglés son los días martes a las 17 hs Colombia
-                  y Perú (GMT-5), 18 hs Venezuela (GMT-4) y 19 hs Argentina
+                  Los eventos de inglés son los días jueves a las 18 hs Colombia
+                  y Perú (GMT-5), 19 hs Venezuela (GMT-4) y 20 hs Argentina
                   (GTM-3)
                 </p>
               </details>
@@ -82,8 +88,8 @@ const Faqs: React.FC<FAQSProps> = ({ preview = false }) => {
                 </summary>
                 <p className="p-4">
                   No es necesario ningún nivel. Solo tener ganas de participar.
-                  Es muy importante que puedas abrir el micrófono y te animes a
-                  hablar.
+                  Es muy importante que puedas activar el micrófono y te animes
+                  a hablar.
                 </p>
               </details>
               <details className="mb-4">
@@ -103,8 +109,11 @@ const Faqs: React.FC<FAQSProps> = ({ preview = false }) => {
                   ¿Cómo me anoto a la mentorías?
                 </summary>
                 <p className="p-4">
-                  Puedes hacerlo directamente en
-                  <a href="https://frontend.cafe/mentorias">
+                  Puedes hacerlo directamente en{' '}
+                  <a
+                    href="https://frontend.cafe/mentorias"
+                    className="text-informational"
+                  >
                     la página de mentorías
                   </a>
                   , ahí coordinarás fecha y hora según los calendarios de los


### PR DESCRIPTION
<!-- Colocar entre las llaves la id de la tarea de clickup -->
#{CU-295bg6u}

<!-- Cuál es la razón por la que se creo este PR -->

<!-- Cambios (opcional, si no se completa eliminar título) -->
# Changes
- Fix event card spacing
- Add blue color to links in FAQS
- Fix FAQS texts
