### PR TITLE
feat(mentors): filter mentor by status

### DIFF
--- a/src/components/MentorCard/index.tsx
+++ b/src/components/MentorCard/index.tsx
@@ -20,6 +20,9 @@ const MentorCard: React.FC<MentorCardProps> = ({
   isLogged,
   openModal,
 }) => {
+  const isActive = mentor.status === 'ACTIVE';
+  const isUnavailable = mentor.status === 'NOT_AVAILABLE';
+
   const findTopicsName = (id: string) => {
     const topic = topics.find((e) => e._id == id);
     return topic.title;
@@ -28,7 +31,7 @@ const MentorCard: React.FC<MentorCardProps> = ({
   return (
     <motion.div
       initial={{ y: 100, opacity: 0 }}
-      animate={{ y: 0, opacity: mentor.isActive ? 1 : 0.66 }}
+      animate={{ y: 0, opacity: isActive ? 1 : 0.66 }}
       exit={{ y: -100, opacity: 0 }}
       className="flex flex-col w-full p-6 rounded-lg bg-zinc-800 space-between "
     >
@@ -48,14 +51,14 @@ const MentorCard: React.FC<MentorCardProps> = ({
 
           <div>
             <div className="mb-4">
-              {!mentor.isActive ? (
+              {isUnavailable ? (
                 <button
                   type="button"
                   className="capitalize cursor-not-allowed text-md btn btn-secondary"
                 >
                   No disponible
                 </button>
-              ) : mentor.isActive && mentor.calendly && isLogged ? (
+              ) : isActive && mentor.calendly && isLogged ? (
                 <Link href={mentor.calendly}>
                   <a
                     target="_blank"

--- a/src/components/MentorList/index.tsx
+++ b/src/components/MentorList/index.tsx
@@ -33,15 +33,18 @@ const MentorList: React.FC<MentorListProps> = ({ mentors, topics }) => {
   };
 
   /**
-   * sort modifies the original orray, so make a copy to be safe
+   * sort modifies the original array, so make a copy to be safe
    */
   const sortedTopics = useMemo(
     () => [...topics].sort((a, b) => a.title.localeCompare(b.title)),
     [topics],
   );
 
+  /**
+   * All active mentors should be first
+   */
   const sortedMentors = useMemo(
-    () => [...mentors].sort((a) => (a.isActive ? -1 : 1)),
+    () => [...mentors].sort((mentor) => (mentor.status === 'ACTIVE' ? -1 : 1)),
     [mentors],
   );
 

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -150,14 +150,14 @@ export const mentorsTopicsQuery = groq`
 `;
 
 export const mentorsQuery = groq`
-  *[_type == "mentor"] | order(date desc) {
+  *[_type == "mentor" && status in ["ACTIVE", "NOT_AVAILABLE"]] | order(date desc) {
     name,
     description,
     'photo': {
       'alt': photo.alt,
       'src': photo.asset->url
     },
-    isActive,
+    status,
     web,
     calendly,
     github,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -100,7 +100,7 @@ export interface Mentor {
     src: string;
     alt?: string;
   };
-  isActive: boolean;
+  status: 'ACTIVE' | 'NOT_AVAILABLE' | 'INACTIVE' | 'OUT';
   web: string;
   calendly: string;
   linkedin: string;


### PR DESCRIPTION
We had an `isActive` boolean status for each mentor.
We now have an `status` enum