### PR TITLE
refactor(components/Hero): move the counter logic to the Hero component

### DIFF
--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -1,12 +1,43 @@
-import { motion } from 'framer-motion';
 import {
-  faExternalLinkAlt,
   faChevronDown,
+  faExternalLinkAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
+
+/**
+ * Hook that returns a counter that increments every `seconds` seconds,
+ * and resets to 0 when it reaches `max`.
+ */
+function useCounter(initialValue: number, max: number, seconds: number) {
+  const [counter, setCounter] = useState(initialValue);
+
+  useEffect(() => {
+    if (max === 0) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setCounter((counter) => {
+        const nextCounter = counter + 1;
+
+        if (nextCounter === max) {
+          return 0;
+        }
+
+        return nextCounter;
+      });
+    }, seconds * 1000);
+
+    return () => clearInterval(interval);
+  }, [max, seconds]);
+
+  return counter;
+}
 
 interface HeroProps {
-  title?: string;
+  heroWords: string[];
   subtitle: string;
   description?: string;
   discordButtonLabel: string;
@@ -15,13 +46,16 @@ interface HeroProps {
 }
 
 const Hero: React.FC<HeroProps> = ({
-  title,
+  heroWords,
   subtitle,
   description,
   discordButtonLabel,
   iniciativasButtonText,
   handleIniciativasClick,
 }) => {
+  const counter = useCounter(0, heroWords.length, 3);
+  const title = heroWords[counter];
+
   return (
     <div className="relative py-32 mx-auto bg-white/0">
       <div className="flex items-center justify-center h-full bg-center bg-cover text-primary md:justify-around">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useRef } from 'react';
 
 import { GetStaticProps } from 'next';
 
@@ -42,7 +42,6 @@ function FeaturedSection({ cards }, ref) {
 const ForwardedFeaturedSection = forwardRef(FeaturedSection);
 
 const Index: React.FC<IndexProps> = ({ preview = false, cards, tweets }) => {
-  const [counter, setCounter] = useState(0);
   const {
     heroWords = ['Creamos'],
     description,
@@ -58,23 +57,11 @@ const Index: React.FC<IndexProps> = ({ preview = false, cards, tweets }) => {
     featuredRef.current.scrollIntoView({ behavior: 'smooth' });
   };
 
-  if (counter >= heroWords?.length) {
-    setCounter(0);
-  }
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCounter((counter) => counter + 1);
-    }, 5000);
-
-    return () => clearInterval(interval);
-  }, []);
-
   return (
     <Layout title="Home" description={description} preview={preview}>
       {/* <CMYKBanner>Es hoy!</CMYKBanner> */}
       <Hero
-        title={heroWords[counter]}
+        heroWords={heroWords}
         subtitle={heroSubtitle}
         description={heroDescription}
         discordButtonLabel={discordButtonLabel}


### PR DESCRIPTION
Mueve la lógica del contador en el hero (para ir cambiando las palabras) al componente Hero en lugar de tener esa lógica en la página, de esa forma se evita un rerender de toda la página ante cada cambio del counter.

También crea un custom hook para poder usar la lógica del counter en otros componentes si es necesario en el futuro (de momento el hook esta en el archivo del componente Hero)

**Antes:**

https://user-images.githubusercontent.com/4043417/206762795-47e6c644-52aa-4441-9b7e-7ad0280bc6a9.mov

**Después:**

https://user-images.githubusercontent.com/4043417/206763170-3a43ab50-2fad-416e-85b6-455e7a3663cf.mov



