### PR TITLE
fix: discord rate limit error breaking prod

### DIFF
--- a/src/app/mentorias/page.tsx
+++ b/src/app/mentorias/page.tsx
@@ -20,8 +20,7 @@ export default async function MentorshipsPage() {
     getAllMentors({ next: { revalidate: 60 } }),
   ]);
 
-  const response = await getAllDiscordEvents();
-  const events = await response.json();
+  const events = await getAllDiscordEvents();
 
   const availableMentors = mentors.filter(
     (mentor) => mentor.status === 'ACTIVE',

--- a/src/components/EventList/index.tsx
+++ b/src/components/EventList/index.tsx
@@ -1,7 +1,7 @@
 import UpcomingEvents from '@/app/eventos/components/UpcomingEvents';
 import { getAllEvents } from '@/lib/api.server';
 import { getAllDiscordEvents } from '@/lib/discord';
-import type { DiscordEvent, Event } from '@/lib/types';
+import type { Event } from '@/lib/types';
 import { isPast } from 'date-fns';
 import EventPreview from '../EventPreview';
 
@@ -13,8 +13,7 @@ export default async function EventList() {
     next: { revalidate: 60 },
   });
 
-  const response = await getAllDiscordEvents();
-  const upcomingEvents: DiscordEvent[] = await response.json();
+  const upcomingEvents = await getAllDiscordEvents();
 
   return (
     <div id="events" className="space-y-20">

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -1,4 +1,5 @@
 import { FrontendCafeId } from './constants';
+import type { DiscordEvent } from './types';
 
 const urlBaseAPIDiscord = 'https://discord.com/api';
 const urlBaseCDNDiscord = 'https://cdn.discordapp.com/';
@@ -12,6 +13,7 @@ export const urlAPIDiscordEvents =
 function get(url: string) {
   const token = process.env.DISCORD_TOKEN;
   return fetch(url, {
+    next: { revalidate: 300 },
     method: 'GET',
     headers: {
       Authorization: `Bot ${token}`,
@@ -19,8 +21,10 @@ function get(url: string) {
   });
 }
 
-export function getAllDiscordEvents(): Promise<Response> {
-  return get(urlAPIDiscordEvents);
+export function getAllDiscordEvents(): Promise<DiscordEvent[]> {
+  return get(urlAPIDiscordEvents).then((events) =>
+    events.ok ? events.json() : [],
+  );
 }
 
 export function getDiscordEventImageUrl(

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -109,14 +109,8 @@ export async function importEvents(preview = false): Promise<number> {
   );
   let countNewEvents = 0;
   try {
-    const response = await getAllDiscordEvents();
+    const discordEventsAllValues = await getAllDiscordEvents();
 
-    if (!response.ok) {
-      const error: unknown = await response.json();
-      throw new Error(`HTTP Error: ${JSON.stringify(error)}`);
-    }
-
-    const discordEventsAllValues: DiscordEvent[] = await response.json();
     discordEventsAllValues.forEach(async (discordEvent) => {
       //
       const importedIndex = importedEventsId?.find(


### PR DESCRIPTION
# Changes

- (Partially) handle error on the function in charge of fetching Discord events that was causing a client-side exception in the mentorships route.